### PR TITLE
npmへの反映トリガーとNode.jsのバージョンを変更

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,10 +1,8 @@
-name: Node.js Package
+name: npm publish
 
 on:
-  workflow_dispatch:
-  push:
-    tags:
-      - v[0-9].[0-9]+.[0-9]+
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -13,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - run: |
           npm ci
           npm run build
@@ -28,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           registry-url: 'https://npm.pkg.github.com'
           scope: '@nekochans'
       - run: |


### PR DESCRIPTION
# 内容
- GItHubPackagesへの反映トリガーをGitHub上でリリースページが公開されたタイミングに変更
- Node.js 16が安定版になったのでNode.js16系を利用するように変更
